### PR TITLE
Fix usage of GKE CloudCredential in capabilities

### DIFF
--- a/pkg/api/norman/customization/gke/handler.go
+++ b/pkg/api/norman/customization/gke/handler.go
@@ -141,10 +141,18 @@ func (h *handler) getCloudCredentials(req *http.Request, cap *Capabilities, cred
 		logrus.Debugf("[GKE] error accessing cloud credential %s", credID)
 		return fmt.Errorf("error accessing cloud credential %s", credID)
 	}
-	cap.Credentials = string(cc.Data["authEncodedJson"])
+	cap.Credentials = string(cc.Data["googlecredentialConfig-authEncodedJson"])
 	region := req.URL.Query().Get("region")
 	if region != "" {
 		cap.Region = region
+	}
+	zone := req.URL.Query().Get("zone")
+	if zone != "" {
+		cap.Zone = zone
+	}
+	projectId := req.URL.Query().Get("projectId")
+	if projectId != "" {
+		cap.ProjectID = projectId
 	}
 
 	return nil


### PR DESCRIPTION
When referencing a GKE CloudCredential instead of POSTing the credential
object to the capabilities API, the Secret behind the credential wasn't
being parsed properly, and the request was missing parameters that are
required to access the proxied GKE APIs. This patch adds the missing
zone and project ID parameters to the parsed query string and corrects
the Secret key that refers to the credential object. Now a request will
need to be made with all four parameters like this:

```
$ curl -u $TOKEN "https://localhost:8443/meta/gkeSubnetworks?cloudCredentialId=cattle-global-data:cc-abcde&region=us-west1&zone=us-west1-a&projectId=my-project-id"
```